### PR TITLE
Fix path to custom .env file in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ If you want to use a custom .env file for the Behat tests you will need to modif
 
 ```php
 try {
-    (new Dotenv\Dotenv(__DIR__.'/../', isset($dotEnvFile) ?: '.env'))->load();
+    (new Dotenv\Dotenv(__DIR__.'/../', isset($dotEnvFile) ? $dotEnvFile : '.env'))->load();
 } catch (Dotenv\Exception\InvalidPathException $e) {
     //
 }


### PR DESCRIPTION
The expression `isset($dotEnvFile) ?: '.env'` will give us either `true` or `'.env'`, but never `'.env.behat'`:

> Expression expr1 ?: expr3 returns expr1 if expr1 evaluates to TRUE, and expr3 otherwise.

From http://php.net/manual/en/language.operators.comparison.php#language.operators.comparison.ternary.